### PR TITLE
Added isDefaultClientSet() method to FedoraRequest

### DIFF
--- a/fedora-client-core/src/main/java/com/yourmediashelf/fedora/client/request/FedoraRequest.java
+++ b/fedora-client-core/src/main/java/com/yourmediashelf/fedora/client/request/FedoraRequest.java
@@ -64,6 +64,15 @@ public abstract class FedoraRequest<T> {
     }
     
     /**
+     * Return boolean indicating whether {@link #DEFAULT_CLIENT} has been set.
+     * 
+     * @return boolean
+     */
+    public static boolean isDefaultClientSet() {
+    	return (DEFAULT_CLIENT != null);
+    }
+    
+    /**
      * <p>Execute this request using the supplied FedoraClient instance.</p>
      *
      * @param fedora an instance of FedoraClient


### PR DESCRIPTION
Hey Eddie,

This is following up on our recent email.  I'm a git and github newbie, so please forgive any mistakes.  I didn't write a unit test and haven't tested the code -- I can't build the fedora-client source in Eclipse due to errors which I won't get into here.  In any case, this is obviously a pretty straightforward addition.  The new method could be used also in execute(), but I thought it better to leave that up to you.

Thanks,
David
